### PR TITLE
WIP: Bump to 2.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.5.39" %}
+{% set version = "2.6.0" %}
 
 package:
   name: flex
@@ -7,18 +7,11 @@ package:
 source:
   fn: flex-{{ version }}.tar.gz
   url: http://sourceforge.net/projects/flex/files/flex-{{ version }}.tar.gz
-  md5: e133e9ead8ec0a58d81166b461244fde
-  patches:
-    # Patch the Makefile.am based on a bug report on SourceForge.
-    # https://sourceforge.net/p/flex/bugs/182/
-    - Makefile.am.patch
-    # Patch the Makefile.am based on a bug report on SourceForge.
-    # https://sourceforge.net/p/flex/bugs/169/
-    - 0001-bison-test-fixes-Do-not-use-obsolete-bison-construct.patch
+  md5: 5724bcffed4ebe39e9b55a9be80859ec
 
 build:
   skip: true  # [win]
-  number: 1
+  number: 0
   detect_binary_files_with_prefix: true
 
 requirements:


### PR DESCRIPTION
Upgrades `flex` to version `2.6.0`.

Still very much WIP.

Patches are dropped as they are included in that release.
