### PR TITLE
Remove bison dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
 
 requirements:
@@ -28,7 +28,6 @@ requirements:
     - libiconv
     - libtool
     - m4
-    - bison
 
   run:
     - libiconv


### PR DESCRIPTION
This removes a circular dependency problem because right now bison depends on flex too:

https://github.com/conda-forge/bison-feedstock/blob/master/recipe/meta.yaml#L20

However, that dependency is right, but not the one of flex on bison:

https://gitweb.gentoo.org/repo/gentoo.git/tree/sys-devel/flex/flex-2.6.1.ebuild

I noticed this while trying to build both packages locally ;-)
