### PR TITLE
Build long prefix package using conda-build 2.x

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,14 @@ install:
       conda install --yes --quiet conda-forge-build-setup
       source run_conda_forge_build_setup
 
+      # install conda-build 2.x to build with a long prefix
+      conda install --yes --quiet conda-build=2
+      conda info
+
 script:
   - conda build ./recipe
 
   - upload_or_check_non_existence ./recipe conda-forge --channel=main
+
+  # inspect the prefix lengths of the built packages
+  - conda inspect prefix-lengths /Users/travis/miniconda3/conda-bld/osx-64/*.tar.bz2

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: The Fast Lexical Analyzer
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/flex-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/flex-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/flex-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/flex-feedstock)
+Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/flex/badges/version.svg)](https://anaconda.org/conda-forge/flex)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/flex/badges/downloads.svg)](https://anaconda.org/conda-forge/flex)
+
 Installing flex
 ===============
 
@@ -31,7 +43,6 @@ It is possible to list all of the versions of `flex` available on your platform 
 ```
 conda search flex --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -67,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/flex-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/flex-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/flex-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/flex-feedstock)
-Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/flex/badges/version.svg)](https://anaconda.org/conda-forge/flex)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/flex/badges/downloads.svg)](https://anaconda.org/conda-forge/flex)
 
 
 Updating flex-feedstock

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,7 +41,14 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
+# install conda-build 2.x to build a long prefix
+conda install --yes --quiet conda-build=2
+conda info
+
 # Embarking on 1 case(s).
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+# inspect the prefix lengths of the built packages
+conda inspect prefix-lengths /feedstock_root/build_artefacts/linux-64/*.tar.bz2
 EOF

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-autoreconf
 ./configure --prefix="$PREFIX"
 make
 make check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ build:
 
 requirements:
   build:
-    - autoconf
     - automake
     - libiconv
     - libtool


### PR DESCRIPTION
Also removed use of autoreconf in build as this should not, as least as far as I can tell, be needed.